### PR TITLE
Strip TinyAuth session cookie before proxying upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Available snippets (defined in `hosts/base.conf`):
 - `(compression)` - zstd/gzip compression
 - `(header)` - security headers (HSTS, no indexing, hide server info)
 - `(performance)` - static asset caching (1 year), skip logs for favicon/robots
-- `(security)` - block .env, .git, .bak, .sql, and other sensitive files
+- `(security)` - block .env, .git, .bak, .sql, and other sensitive files; strip the TinyAuth session cookie before proxying upstream
 
 **Opt-in** (enable with `CADDY_*=true`):
 - `(logging)` - request logging to stdout
@@ -203,6 +203,26 @@ make up-auth
 ```
 
 TinyAuth trusts Docker's `172.16.0.0/12` bridge range by default for forwarded client IP headers.
+
+### Session cookie isolation
+
+TinyAuth scopes its session cookie to the parent domain so single sign-on works
+across subdomains. The browser therefore sends it to *every* site under that
+domain, and a reverse proxy would normally hand it to the backend — giving each
+service a credential that only TinyAuth needs. A compromised backend could
+replay that session against every other protected service.
+
+The `(security)` snippet removes the `tinyauth-session` cookie from the request
+before it reaches the backend. `forward_auth` still sees the untouched cookie,
+so authentication is unaffected, and the backend's own cookies are preserved.
+
+`TINYAUTH_DOMAIN` is excluded from the stripping — TinyAuth must keep reading
+its own session. Set it in `.env` whenever you run with auth; the value is
+passed through to the Caddy container automatically.
+
+> **Note:** if you run TinyAuth but leave `TINYAUTH_DOMAIN` unset, its own host
+> gets stripped too and nobody can log in. Deployments without TinyAuth are
+> unaffected — there is no such cookie to remove.
 
 Then enable per service:
 ```yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       - CF_API_TOKEN
       - HETZNER_API_TOKEN
       - EMAIL
+      # Excluded from SSO cookie stripping in (security) - TinyAuth must keep
+      # reading its own session cookie
+      - TINYAUTH_DOMAIN=${TINYAUTH_DOMAIN:-tinyauth.invalid}
     entrypoint: /docker/entrypoint.sh
     command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
     volumes:

--- a/hosts/base.conf
+++ b/hosts/base.conf
@@ -105,6 +105,7 @@
 }
 
 # (security) - Block access to sensitive files (.env, .git, backups, etc.)
+# and keep the TinyAuth SSO session cookie away from backends
 (security) {
     @sensitive {
         path *.bak *.conf *.dist *.env *.fla *.ini *.inc *.inci *.log *.orig *.psd *.sh *.sql *.swo *.swp *.swop */.*
@@ -114,6 +115,21 @@
 
     @devfiles path /composer.json /composer.lock /package.json /package-lock.json /yarn.lock /.git/* /README.md /CHANGELOG.md /LICENSE.md /CONTRIBUTING.md
     respond @devfiles 403
+
+    # TinyAuth scopes its session cookie to the parent domain so single sign-on
+    # works across subdomains. Consequence: the browser sends it to every site
+    # under that domain, and Caddy passes it upstream - so every backend sees a
+    # credential only TinyAuth needs. A compromised backend could replay it
+    # against other protected services, so strip it before proxying.
+    #
+    # forward_auth still receives the untouched cookie (it captures the original
+    # request), so authentication is unaffected. TinyAuth's own host is excluded,
+    # otherwise it could no longer read its own session.
+    #
+    # The three alternatives cover the cookie appearing first, last, in the
+    # middle, or alone, without leaving a stray separator behind.
+    @sso-cookie-consumer not host {$TINYAUTH_DOMAIN:tinyauth.invalid}
+    request_header @sso-cookie-consumer Cookie ";\s*tinyauth-session=[^;]*|tinyauth-session=[^;]*;\s*|tinyauth-session=[^;]*" ""
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

TinyAuth scopes its session cookie to the parent domain so SSO works across subdomains — `GetCookieDomain` strips the leftmost label of `TINYAUTH_APP_URL`:

```go
// internal/utils/app_utils.go
if !subdomainsEnabled || len(parts) == 2 {
    return hostname, nil
}
return strings.Join(parts[1:], "."), nil
```

Consequence: the browser sends the cookie to **every** site under that domain, and Caddy passes request headers upstream unchanged. Every backend — including ones that don't use `CADDY_AUTH` at all — receives a credential only TinyAuth needs.

A compromised backend can harvest it and replay it against every other protected service. The group checks don't help, because the session is genuine. Realistic vector is a backdoored container image rather than XSS, since the cookie is `HttpOnly` and `SameSite=Lax`.

## Change

`(security)` now removes TinyAuth's cookies from the request before it reaches the backend. That snippet is auto-imported into every generated site, so no watcher change is required and manual configs are covered too.

`forward_auth` captures the original request and still sees the untouched cookie — authentication is unaffected. The backend's own cookies are preserved.

TinyAuth's own host is excluded via `TINYAUTH_DOMAIN`, which is now passed through to the Caddy container (defaulting to `tinyauth.invalid`).

### Cookie names are suffixed

The rule matches the `tinyauth-` prefix rather than literal names. TinyAuth appends the first 8 characters of a hostname-derived UUID to every cookie:

```go
// internal/bootstrap/app_bootstrap.go
cookieId := strings.Split(app.runtime.UUID, "-")[0]
app.runtime.SessionCookieName = fmt.Sprintf("%s-%s", model.SessionCookieName, cookieId)
```

So the real name is e.g. `tinyauth-session-8b2f3e83`. Matching the prefix also covers `tinyauth-csrf`, `tinyauth-redirect` and `tinyauth-oauth`, plus anything added later — a backend has no use for any of them.

## Verification

Directive ordering — `forward_auth` sees the cookie, the backend does not:

```
AUTH-SAH: tinyauth-session=GEHEIM; theme=dark
APP-SAH:  [theme=dark]
```

Cookie stripping, running the real snippet from this branch with `TINYAUTH_DOMAIN=login.example.com`:

| Request host | Cookie header in | Reaching backend |
|---|---|---|
| `app.example.com` | `tinyauth-session-8b2f3e83=X; theme=dark` | `theme=dark` |
| `app.example.com` | `theme=dark; tinyauth-session-8b2f3e83=X` | `theme=dark` |
| `app.example.com` | `a=1; tinyauth-session-8b2f3e83=X; b=2` | `a=1; b=2` |
| `app.example.com` | all four `tinyauth-*` cookies + `theme=dark` | `theme=dark` |
| `app.example.com` | `tinyauth-session-8b2f3e83=X` | *(empty)* |
| `app.example.com` | `theme=dark; lang=de` | `theme=dark; lang=de` |
| `login.example.com` | `tinyauth-session-8b2f3e83=X; theme=dark` | unchanged |

`caddy validate` adapts cleanly.

## Upgrade note

Deployments running TinyAuth must have `TINYAUTH_DOMAIN` set in `.env` — it is already documented in `.env.example`, but was previously only consumed by `docker-compose.auth.yml`. If it is unset while TinyAuth is running, TinyAuth's own host gets stripped too and logins fail. Deployments without TinyAuth are unaffected.

## Not done here

`TINYAUTH_AUTH_SUBDOMAINSENABLED=false` looks like an alternative fix but is not one: the cookie would become host-only on the TinyAuth host, so `forward_auth` from any other subdomain would never see a session and every request would be rejected.