### PR TITLE
Match suffixed TinyAuth cookie names

### DIFF
--- a/hosts/base.conf
+++ b/hosts/base.conf
@@ -126,10 +126,16 @@
     # request), so authentication is unaffected. TinyAuth's own host is excluded,
     # otherwise it could no longer read its own session.
     #
-    # The three alternatives cover the cookie appearing first, last, in the
+    # TinyAuth suffixes every cookie name with the first 8 characters of a UUID
+    # derived from its hostname (tinyauth-session-8b2f3e83, tinyauth-csrf-...,
+    # tinyauth-redirect-..., tinyauth-oauth-...), so the names cannot be
+    # hardcoded. Match the tinyauth- prefix instead, which also covers any
+    # cookie the project adds later.
+    #
+    # The three alternatives cover a cookie appearing first, last, in the
     # middle, or alone, without leaving a stray separator behind.
     @sso-cookie-consumer not host {$TINYAUTH_DOMAIN:tinyauth.invalid}
-    request_header @sso-cookie-consumer Cookie ";\s*tinyauth-session=[^;]*|tinyauth-session=[^;]*;\s*|tinyauth-session=[^;]*" ""
+    request_header @sso-cookie-consumer Cookie ";\s*tinyauth-[^=;]*=[^;]*|tinyauth-[^=;]*=[^;]*;\s*|tinyauth-[^=;]*=[^;]*" ""
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #29, which shipped a rule that never fires.

## Problem

#29 matched the literal cookie name `tinyauth-session`. That name only exists as a constant in the source — at runtime TinyAuth appends the first 8 characters of a hostname-derived UUID to every cookie name:

```go
// internal/bootstrap/app_bootstrap.go
cookieId := strings.Split(app.runtime.UUID, "-")[0]
app.runtime.SessionCookieName = fmt.Sprintf("%s-%s", model.SessionCookieName, cookieId)
```

The actual cookie is `tinyauth-session-8b2f3e83`, confirmed in a browser against a live session. The regex expects `=` directly after `tinyauth-session`, so it matched nothing and the rule was a no-op. Harmless, but it did not do its job.

## Change

Match the `tinyauth-` prefix instead of literal names:

```
;\s*tinyauth-[^=;]*=[^;]*|tinyauth-[^=;]*=[^;]*;\s*|tinyauth-[^=;]*=[^;]*
```

This also covers `tinyauth-csrf-*`, `tinyauth-redirect-*` and `tinyauth-oauth-*` — a backend has no use for any of them — and anything the project adds later.

## Verification

Real snippet from this branch, `TINYAUTH_DOMAIN=login.example.com`:

| Request host | Cookie header in | Reaching backend |
|---|---|---|
| `app.example.com` | `tinyauth-session-8b2f3e83=X; theme=dark` | `theme=dark` |
| `app.example.com` | `theme=dark; tinyauth-session-8b2f3e83=X` | `theme=dark` |
| `app.example.com` | `a=1; tinyauth-session-8b2f3e83=X; b=2` | `a=1; b=2` |
| `app.example.com` | all four `tinyauth-*` cookies + `theme=dark` | `theme=dark` |
| `app.example.com` | `tinyauth-session-8b2f3e83=X` | *(empty)* |
| `app.example.com` | `theme=dark; lang=de` | `theme=dark; lang=de` |
| `login.example.com` | `tinyauth-session-8b2f3e83=X; theme=dark` | unchanged |