### PR TITLE
SSO-Cookie-Bereinigung zuruecknehmen - sie zerstoert die Anmeldung

### DIFF
--- a/hosts/base.conf
+++ b/hosts/base.conf
@@ -105,7 +105,6 @@
 }
 
 # (security) - Block access to sensitive files (.env, .git, backups, etc.)
-# and keep the TinyAuth SSO session cookie away from backends
 (security) {
     @sensitive {
         path *.bak *.conf *.dist *.env *.fla *.ini *.inc *.inci *.log *.orig *.psd *.sh *.sql *.swo *.swp *.swop */.*
@@ -116,26 +115,33 @@
     @devfiles path /composer.json /composer.lock /package.json /package-lock.json /yarn.lock /.git/* /README.md /CHANGELOG.md /LICENSE.md /CONTRIBUTING.md
     respond @devfiles 403
 
-    # TinyAuth scopes its session cookie to the parent domain so single sign-on
-    # works across subdomains. Consequence: the browser sends it to every site
-    # under that domain, and Caddy passes it upstream - so every backend sees a
-    # credential only TinyAuth needs. A compromised backend could replay it
-    # against other protected services, so strip it before proxying.
+    # Zurueckgenommen: die SSO-Cookie-Bereinigung hat die Anmeldung zerstoert.
     #
-    # forward_auth still receives the untouched cookie (it captures the original
-    # request), so authentication is unaffected. TinyAuth's own host is excluded,
-    # otherwise it could no longer read its own session.
+    # Caddy ordnet Direktiven nach fester Rangfolge, und `header` steht vor
+    # `handle`. Die Bereinigung lief damit VOR `forward_auth`, sodass TinyAuth
+    # eine Anfrage ohne seinen eigenen Sitzungscookie bekam und jede Anmeldung
+    # mit 302 beantwortete - eine Endlosschleife auf allen geschuetzten Hosts.
     #
-    # TinyAuth suffixes every cookie name with the first 8 characters of a UUID
-    # derived from its hostname (tinyauth-session-8b2f3e83, tinyauth-csrf-...,
-    # tinyauth-redirect-..., tinyauth-oauth-...), so the names cannot be
-    # hardcoded. Match the tinyauth- prefix instead, which also covers any
-    # cookie the project adds later.
+    # Nachweisbar an `caddy adapt`:
+    #     headers request=replace   <- Bereinigung
+    #     reverse_proxy -> tinyauth (forward_auth)
+    #     reverse_proxy -> backend
     #
-    # The three alternatives cover a cookie appearing first, last, in the
-    # middle, or alone, without leaving a stray separator behind.
-    @sso-cookie-consumer not host {$TINYAUTH_DOMAIN:tinyauth.invalid}
-    request_header @sso-cookie-consumer Cookie ";\s*tinyauth-[^=;]*=[^;]*|tinyauth-[^=;]*=[^;]*;\s*|tinyauth-[^=;]*=[^;]*" ""
+    # Damit das Anliegen - der Backend soll den SSO-Cookie nicht sehen -
+    # trotzdem umsetzbar bleibt, muss die Bereinigung ZWISCHEN forward_auth und
+    # dem Backend laufen. Das erfordert einen route-Block in den erzeugten
+    # Host-Dateien, der die Reihenfolge festschreibt, statt einer Anweisung auf
+    # Site-Ebene:
+    #
+    #     handle @internal {
+    #         route {
+    #             forward_auth ... { }
+    #             request_header Cookie "..." ""
+    #             reverse_proxy backend:port
+    #         }
+    #     }
+    #
+    # Das gehoert in den Watcher, der die Host-Dateien erzeugt.
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

Jeder geschuetzte Host laeuft in eine Endlosschleife zwischen Backend und Login. TinyAuth beantwortet `/api/auth/caddy` im Sekundentakt mit 302.

## Ursache

Caddy ordnet Direktiven nach einer festen Rangfolge, in der `header` vor `handle` steht. Die in #29/#30 eingefuehrte Bereinigung lief dadurch **vor** `forward_auth` — TinyAuth bekam eine Anfrage ohne seinen eigenen Sitzungscookie und lehnte folgerichtig ab.

Nachweisbar an `caddy adapt`:

```
subroute
    headers request=replace                       <- Bereinigung
    subroute
        reverse_proxy -> tinyauth  (forward_auth) <- laeuft danach
        reverse_proxy -> backend
```

Der Kommentar im Code behauptete das Gegenteil (*"forward_auth still receives the untouched cookie"*). Das war eine Annahme, keine Messung.

Bemerkenswert: Der Fehler wurde erst mit #30 wirksam. Davor passte die Regex nicht auf die tatsaechlichen Cookienamen mit UUID-Suffix — die Bereinigung tat nichts, und die Anmeldung funktionierte deshalb.

## Was jetzt gilt

Zustand wie vor #29: Backends sehen den SSO-Cookie wieder. Das war monatelang so und ist kein neu entstandenes Risiko.

## Der Weg zur richtigen Loesung

Die Bereinigung muss **zwischen** forward_auth und Backend laufen. Das geht nur mit einem `route`-Block in den erzeugten Host-Dateien, weil `route` die geschriebene Reihenfolge beibehaelt:

```
handle @internal {
    route {
        forward_auth ... { }
        request_header Cookie "..." ""
        reverse_proxy backend:port
    }
}
```

Das gehoert in den Watcher. `TINYAUTH_DOMAIN` bleibt deshalb in der Compose-Datei stehen.