### PR TITLE
SSO-Cookie am Backend entfernen statt auf Site-Ebene

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,9 @@ services:
       - COMPOSE_PROJECT_NAME
       - NETWORK_SUFFIX=${NETWORK_SUFFIX:-_caddy}
       - HOSTS_DIR=${HOSTS_DIR:-/hosts}
+      # Needed so the watcher can exempt TinyAuth's own host from the SSO cookie
+      # strip - without it TinyAuth could no longer read its own session.
+      - TINYAUTH_DOMAIN=${TINYAUTH_DOMAIN:-}
       - DNS_REFRESH_INTERVAL=${DNS_REFRESH_INTERVAL:-60}
       # Status page: set CADDY_DOMAIN in .env to enable
       - CADDY_DOMAIN=${CADDY_DOMAIN:-}

--- a/hosts/base.conf
+++ b/hosts/base.conf
@@ -115,33 +115,13 @@
     @devfiles path /composer.json /composer.lock /package.json /package-lock.json /yarn.lock /.git/* /README.md /CHANGELOG.md /LICENSE.md /CONTRIBUTING.md
     respond @devfiles 403
 
-    # Zurueckgenommen: die SSO-Cookie-Bereinigung hat die Anmeldung zerstoert.
+    # Die TinyAuth-Sitzungscookies werden nicht hier entfernt, sondern am
+    # reverse_proxy zum Backend - der Watcher setzt dafuer ein header_up in die
+    # erzeugten Host-Dateien.
     #
-    # Caddy ordnet Direktiven nach fester Rangfolge, und `header` steht vor
-    # `handle`. Die Bereinigung lief damit VOR `forward_auth`, sodass TinyAuth
-    # eine Anfrage ohne seinen eigenen Sitzungscookie bekam und jede Anmeldung
-    # mit 302 beantwortete - eine Endlosschleife auf allen geschuetzten Hosts.
-    #
-    # Nachweisbar an `caddy adapt`:
-    #     headers request=replace   <- Bereinigung
-    #     reverse_proxy -> tinyauth (forward_auth)
-    #     reverse_proxy -> backend
-    #
-    # Damit das Anliegen - der Backend soll den SSO-Cookie nicht sehen -
-    # trotzdem umsetzbar bleibt, muss die Bereinigung ZWISCHEN forward_auth und
-    # dem Backend laufen. Das erfordert einen route-Block in den erzeugten
-    # Host-Dateien, der die Reihenfolge festschreibt, statt einer Anweisung auf
-    # Site-Ebene:
-    #
-    #     handle @internal {
-    #         route {
-    #             forward_auth ... { }
-    #             request_header Cookie "..." ""
-    #             reverse_proxy backend:port
-    #         }
-    #     }
-    #
-    # Das gehoert in den Watcher, der die Host-Dateien erzeugt.
+    # Auf Site-Ebene ginge es nicht: Caddy ordnet `header` vor `handle`, die
+    # Bereinigung liefe also vor `forward_auth`. TinyAuth bekaeme eine Anfrage
+    # ohne seinen eigenen Sitzungscookie und wuerde jede Anmeldung ablehnen.
 }
 
 # -----------------------------------------------------------------------------

--- a/watcher/caddy.go
+++ b/watcher/caddy.go
@@ -110,22 +110,81 @@ func (m *CaddyManager) resolveTrustedProxies(entries []string) []string {
 	return allIPs
 }
 
+// ssoCookiePattern removes TinyAuth's cookies from a Cookie header.
+//
+// Two alternatives, and both need care:
+//
+//   ^(?:tinyauth-[^=;]*=[^;]*(?:;\s*|$))+   leading run of TinyAuth cookies
+//   ;\s*tinyauth-[^=;]*=[^;]*               any later one, with its separator
+//
+// The leading alternative repeats (+) on purpose. Replacement scans left to
+// right and never rewinds, so after consuming the first cookie the anchor no
+// longer matches - without the repetition a second consecutive cookie at the
+// start would survive. TinyAuth sets four (session, csrf, redirect, oauth), so
+// that case is the norm, not an edge case.
+//
+// Both alternatives are anchored, either at the start of the header or behind a
+// separator. Matching the bare prefix would eat into unrelated cookies: with an
+// unanchored pattern, "mytinyauth-session=x; a=1" collapses to "mya=1" - a
+// silently corrupted header.
+const ssoCookiePattern = `^(?:tinyauth-[^=;]*=[^;]*(?:;\s*|$))+|;\s*tinyauth-[^=;]*=[^;]*`
+
+// ssoCookieStripDirective returns a header_up directive that removes TinyAuth's
+// session cookies from the request before it reaches the backend.
+//
+// TinyAuth scopes its cookie to the parent domain so single sign-on works across
+// subdomains. The browser therefore sends it to every site under that domain, and
+// without this the backend would see a credential only TinyAuth needs - a
+// compromised backend could replay it against every other protected service.
+//
+// This must sit on the reverse_proxy to the BACKEND, not on the site. A site-level
+// request_header would run before forward_auth, because Caddy sorts header ahead of
+// handle - TinyAuth would then be asked to authenticate a request stripped of its
+// own session and would reject every login. header_up only rewrites the request
+// going upstream, so the forward_auth call is untouched by construction.
+//
+// TinyAuth's own host is exempt: it must still read its session. The cookie names
+// carry a suffix derived from the hostname (tinyauth-session-8b2f3e83, tinyauth-csrf-...),
+// so the prefix is matched instead. The three alternatives cover a cookie appearing
+// first, last, in the middle, or alone, without leaving a stray separator behind.
+func ssoCookieStripDirective(cfg *CaddyConfig) string {
+	tinyauthDomain := strings.TrimSpace(os.Getenv("TINYAUTH_DOMAIN"))
+	if tinyauthDomain != "" {
+		for _, d := range cfg.Domains {
+			if strings.EqualFold(strings.TrimSpace(d), tinyauthDomain) {
+				return ""
+			}
+		}
+	}
+	return `header_up Cookie "` + ssoCookiePattern + `" ""`
+}
+
 // generateReverseProxyBlock generates the reverse_proxy directive with optional trusted_proxies
 // indent is the base indentation (e.g., "        " for 8 spaces)
-// extraDirective is an optional additional directive inside the block (e.g., "header_up X-Real-IP ...")
-func (m *CaddyManager) generateReverseProxyBlock(cfg *CaddyConfig, indent string, extraDirective string) string {
+// extraDirectives are optional additional directives inside the block (e.g., "header_up X-Real-IP ...")
+func (m *CaddyManager) generateReverseProxyBlock(cfg *CaddyConfig, indent string, extraDirectives ...string) string {
 	resolvedProxies := m.resolveTrustedProxies(cfg.TrustedProxies)
 
-	// Simple case: no extra directive and no trusted proxies
-	if extraDirective == "" && len(resolvedProxies) == 0 {
+	var extras []string
+	for _, d := range extraDirectives {
+		if d != "" {
+			extras = append(extras, d)
+		}
+	}
+	if strip := ssoCookieStripDirective(cfg); strip != "" {
+		extras = append(extras, strip)
+	}
+
+	// Simple case: nothing to add
+	if len(extras) == 0 && len(resolvedProxies) == 0 {
 		return indent + "reverse_proxy " + cfg.Upstream
 	}
 
 	// Need block format
 	var lines []string
 	lines = append(lines, indent+"reverse_proxy "+cfg.Upstream+" {")
-	if extraDirective != "" {
-		lines = append(lines, indent+"    "+extraDirective)
+	for _, d := range extras {
+		lines = append(lines, indent+"    "+d)
 	}
 	if len(resolvedProxies) > 0 {
 		lines = append(lines, indent+"    trusted_proxies private_ranges "+strings.Join(resolvedProxies, " "))
@@ -268,7 +327,7 @@ func (m *CaddyManager) WriteConfig(cfg *CaddyConfig) error {
 
 	// Generate reverse_proxy block for internal and cloudflare types
 	if cfg.Type == TypeInternal {
-		rpBlock := m.generateReverseProxyBlock(cfg, "        ", "")
+		rpBlock := m.generateReverseProxyBlock(cfg, "        ")
 		content = strings.ReplaceAll(content, "{{REVERSE_PROXY_BLOCK}}", rpBlock)
 	} else if cfg.Type == TypeCloudflare {
 		rpBlock := m.generateReverseProxyBlock(cfg, "        ", "header_up X-Real-IP {header.CF-Connecting-IP}")
@@ -318,22 +377,11 @@ func (m *CaddyManager) generateAllowlistBlock(cfg *CaddyConfig) string {
 		return ""
 	}
 
-	// Resolve trusted proxies if set
-	resolvedProxies := m.resolveTrustedProxies(cfg.TrustedProxies)
-	trustedProxiesLine := ""
-	if len(resolvedProxies) > 0 {
-		trustedProxiesLine = "\n        trusted_proxies private_ranges " + strings.Join(resolvedProxies, " ")
-	}
-
-	// No allowlist - simple or block reverse_proxy
+	// No allowlist - the shared generator supplies trusted_proxies and, more
+	// importantly, the SSO cookie strip. Building the directive by hand here is
+	// what previously left external backends receiving the TinyAuth cookie.
 	if len(cfg.Allowlist) == 0 {
-		if len(resolvedProxies) == 0 {
-			return fmt.Sprintf(`
-    reverse_proxy %s`, cfg.Upstream)
-		}
-		return fmt.Sprintf(`
-    reverse_proxy %s {%s
-    }`, cfg.Upstream, trustedProxiesLine)
+		return "\n" + m.generateReverseProxyBlock(cfg, "    ")
 	}
 
 	// Get resolved IPs from allowlist manager
@@ -356,13 +404,10 @@ func (m *CaddyManager) generateAllowlistBlock(cfg *CaddyConfig) string {
 		authBlock = generateAuthBlock(cfg.AuthURL, cfg.AuthPaths, cfg.AuthExcept, cfg.AuthGroups) + "\n"
 	}
 
-	// Format reverse_proxy with optional trusted_proxies
-	reverseProxyBlock := fmt.Sprintf("reverse_proxy %s", cfg.Upstream)
-	if len(resolvedProxies) > 0 {
-		reverseProxyBlock = fmt.Sprintf(`reverse_proxy %s {
-            trusted_proxies private_ranges %s
-        }`, cfg.Upstream, strings.Join(resolvedProxies, " "))
-	}
+	// Same generator as everywhere else, so the SSO cookie strip is not forgotten
+	// here either. The template below already indents the first line by eight
+	// spaces, so only that leading indentation is removed.
+	reverseProxyBlock := strings.TrimLeft(m.generateReverseProxyBlock(cfg, "        "), " ")
 
 	// Generate allowlist block (private_ranges always allowed for internal access)
 	// Even if DNS fails, we still restrict to private_ranges - never fall back to open access

--- a/watcher/caddy_test.go
+++ b/watcher/caddy_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"regexp"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2259,5 +2260,184 @@ func TestWriteConfig_ExternalNoGroupsNoErrors(t *testing.T) {
 	}
 	if strings.Contains(contentStr, "import stealth") {
 		t.Error("unexpected import stealth for external without allowlist")
+	}
+}
+
+// TinyAuth scopes its session cookie to the parent domain, so the browser sends it
+// to every subdomain and the backend would otherwise see a credential it must never
+// have. The strip has to sit on the reverse_proxy to the backend, never on the site:
+// Caddy sorts header ahead of handle, so a site-level request_header would run
+// before forward_auth and TinyAuth would reject every login.
+func TestWriteConfig_StripsSSOCookieTowardsBackend(t *testing.T) {
+	t.Setenv("TINYAUTH_DOMAIN", "login.example.com")
+	tmpDir := t.TempDir()
+	mgr := NewCaddyManager(tmpDir, nil)
+
+	cfg := &CaddyConfig{
+		Network:     "test_caddy",
+		Container:   "test-container",
+		Domains:     []string{"app.example.com"},
+		Type:        "internal",
+		Upstream:    "test-container:80",
+		DNSProvider: "cloudflare",
+		Compression: true,
+		Header:      true,
+		Auth:        true,
+	}
+
+	if err := mgr.WriteConfig(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	path := filepath.Join(tmpDir, "internal", "test-container_test_caddy.conf")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	got := string(content)
+
+	if !strings.Contains(got, "header_up Cookie") {
+		t.Error("SECURITY: expected the SSO cookie to be stripped towards the backend")
+	}
+	if !strings.Contains(got, "tinyauth-[^=;]*=[^;]*") {
+		t.Error("SECURITY: expected the cookie name to be matched by prefix, not hardcoded")
+	}
+	// The strip must come after forward_auth, otherwise TinyAuth never sees a session.
+	authAt := strings.Index(got, "forward_auth")
+	stripAt := strings.Index(got, "header_up Cookie")
+	if authAt < 0 || stripAt < 0 || stripAt < authAt {
+		t.Errorf("SECURITY: cookie strip must follow forward_auth, got forward_auth at %d, strip at %d", authAt, stripAt)
+	}
+	// It belongs to the backend proxy, not to the site.
+	if strings.Contains(got, "request_header Cookie") {
+		t.Error("SECURITY: site-level request_header runs before forward_auth and breaks login")
+	}
+}
+
+// TinyAuth's own host must keep its cookie - otherwise it cannot read its session.
+// Checked for every type: an earlier version of this test used the external type,
+// where the strip was never emitted at all, so it passed for the wrong reason.
+func TestWriteConfig_KeepsSSOCookieForTinyAuthItself(t *testing.T) {
+	for _, typ := range []string{"internal", "external", "cloudflare"} {
+		t.Run(typ, func(t *testing.T) {
+			t.Setenv("TINYAUTH_DOMAIN", "login.example.com")
+			tmpDir := t.TempDir()
+			mgr := NewCaddyManager(tmpDir, nil)
+
+			cfg := &CaddyConfig{
+				Network:     "test_caddy",
+				Container:   "tinyauth",
+				Domains:     []string{"login.example.com"},
+				Type:        typ,
+				Upstream:    "tinyauth:3000",
+				DNSProvider: "cloudflare",
+				Compression: true,
+				Header:      true,
+			}
+
+			if err := mgr.WriteConfig(cfg); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			path := filepath.Join(tmpDir, typ, "tinyauth_test_caddy.conf")
+			content, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read config: %v", err)
+			}
+			if strings.Contains(string(content), "header_up Cookie") {
+				t.Error("TinyAuth's own host must keep the cookie, otherwise it cannot read its session")
+			}
+		})
+	}
+}
+
+// Every generated backend proxy must strip the cookie, not just the internal ones.
+// The external paths used to build their reverse_proxy by hand and were skipped.
+func TestWriteConfig_StripsSSOCookieForEveryType(t *testing.T) {
+	cases := []struct {
+		name      string
+		typ       string
+		allowlist []string
+	}{
+		{"internal", "internal", nil},
+		{"cloudflare", "cloudflare", nil},
+		{"external without allowlist", "external", nil},
+		{"external with allowlist", "external", []string{"192.0.2.1"}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("TINYAUTH_DOMAIN", "login.example.com")
+			tmpDir := t.TempDir()
+			mgr := NewCaddyManager(tmpDir, nil)
+
+			cfg := &CaddyConfig{
+				Network:     "test_caddy",
+				Container:   "test-container",
+				Domains:     []string{"app.example.com"},
+				Type:        c.typ,
+				Upstream:    "test-container:80",
+				Allowlist:   c.allowlist,
+				DNSProvider: "cloudflare",
+				Compression: true,
+				Header:      true,
+			}
+
+			if err := mgr.WriteConfig(cfg); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			path := filepath.Join(tmpDir, c.typ, "test-container_test_caddy.conf")
+			content, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read config: %v", err)
+			}
+			if !strings.Contains(string(content), "header_up Cookie") {
+				t.Errorf("SECURITY: backend still receives the TinyAuth cookie for type %q", c.name)
+			}
+		})
+	}
+}
+
+// The pattern runs inside Caddy against real Cookie headers, so it is verified
+// here with Go's own engine rather than by reading it.
+func TestSSOCookiePattern(t *testing.T) {
+	re, err := regexp.Compile(ssoCookiePattern)
+	if err != nil {
+		t.Fatalf("pattern does not compile: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"alone", "tinyauth-session-8b2f3e83=abc123", ""},
+		{"first", "tinyauth-session-8b2f3e83=abc; sid=42", "sid=42"},
+		{"last", "sid=42; tinyauth-session-8b2f3e83=abc", "sid=42"},
+		{"middle", "a=1; tinyauth-csrf-8b2f3e83=x; b=2", "a=1; b=2"},
+		{"two in the middle", "a=1; tinyauth-session-1=x; tinyauth-csrf-2=y; b=2", "a=1; b=2"},
+		// TinyAuth sets session, csrf, redirect and oauth - all four leading is the norm.
+		{"all four leading", "tinyauth-session-1=a; tinyauth-csrf-1=b; tinyauth-redirect-1=c; tinyauth-oauth-1=d", ""},
+		{"leading run then foreign", "tinyauth-session-1=a; tinyauth-csrf-1=b; sid=9", "sid=9"},
+		{"scattered", "tinyauth-a=1; x=2; tinyauth-b=3; y=4", "x=2; y=4"},
+		{"none", "sid=42; theme=dark", "sid=42; theme=dark"},
+		{"empty", "", ""},
+		{"value contains equals", "a=1; tinyauth-session-1=abc==; b=2", "a=1; b=2"},
+		{"no space after semicolon", "a=1;tinyauth-x=1;b=2", "a=1;b=2"},
+		// Without anchoring these would be cut mid-name and corrupt the header.
+		{"foreign prefix", "mytinyauth-session=x; a=1", "mytinyauth-session=x; a=1"},
+		{"foreign similar name", "tinyauthx=1; a=1", "tinyauthx=1; a=1"},
+		{"tinyauth only as value", "session=tinyauth-foo; a=1", "session=tinyauth-foo; a=1"},
+		{"foreign prefix in the middle", "a=1; xtinyauth-session=y; b=2", "a=1; xtinyauth-session=y; b=2"},
+		{"foreign prefix leading", "xtinyauth-a=1; b=2", "xtinyauth-a=1; b=2"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := re.ReplaceAllString(c.in, ""); got != c.want {
+				t.Errorf("SECURITY: %q\n  got  %q\n  want %q", c.in, got, c.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Zweiter Anlauf fuer das Anliegen aus #29, nach der Ruecknahme in #31.

## Warum der erste Versuch scheiterte

Die Bereinigung stand als `request_header` im `(security)`-Snippet, also auf Site-Ebene. Caddy ordnet Direktiven nach fester Rangfolge, und `header` steht vor `handle` — sie lief damit vor `forward_auth`. TinyAuth bekam eine Anfrage ohne seinen eigenen Sitzungscookie und beantwortete jede Anmeldung mit 302.

## Was jetzt anders ist

`header_up` am `reverse_proxy` zum Backend. Das wirkt ausschliesslich auf die Anfrage nach oben — der `forward_auth`-Aufruf ist damit **von der Bauweise her** unberuehrt, statt sich auf eine gluecklich gewaehlte Reihenfolge zu verlassen.

```
handle @internal {
    forward_auth tinyauth:3000 { ... }        <- sieht den Cookie
    reverse_proxy backend:80 {
        header_up Cookie "...tinyauth-..." ""   <- Backend sieht ihn nicht
    }
}
```

TinyAuths eigener Host wird ueber `TINYAUTH_DOMAIN` ausgenommen; sonst koennte er seine eigene Sitzung nicht mehr lesen.

## Tests

`TestWriteConfig_StripsSSOCookieTowardsBackend` prueft, dass die Bereinigung **nach** `forward_auth` steht und **nicht** als `request_header` auf Site-Ebene auftaucht — genau der Fehler aus #29.

`TestWriteConfig_KeepsSSOCookieForTinyAuthItself` prueft die Ausnahme.

`go build` und `go test ./...` laufen durch.